### PR TITLE
Various fixes and UI improvements: link updates, balance formatting, and deploy contract in new tab

### DIFF
--- a/src/shared/constant/index.ts
+++ b/src/shared/constant/index.ts
@@ -439,10 +439,9 @@ export const TO_LOCALE_STRING_CONFIG = {
 export const SUPPORTED_DOMAINS = ['sats', 'unisat', 'x', 'btc'];
 export const SAFE_DOMAIN_CONFIRMATION = 3;
 
-export const GITHUB_URL = 'https://github.com/unisat-wallet/extension';
-export const DISCORD_URL = 'https://discord.com/invite/EMskB2sMz8';
-export const TWITTER_URL = 'https://twitter.com/unisat_wallet';
-export const TELEGRAM_URL = 'https://t.me/UniSat_Official ';
+export const GITHUB_URL = 'https://github.com/btc-vision/opwallet';
+export const TWITTER_URL = 'https://x.com/opnetbtc';
+export const TELEGRAM_URL = 'https://t.me/opnetbtc ';
 
 export const CHANNEL = process.env.channel!;
 export const VERSION = process.env.release!;

--- a/src/ui/components/OpNetBalanceCard/index.tsx
+++ b/src/ui/components/OpNetBalanceCard/index.tsx
@@ -19,7 +19,11 @@ export interface OpNetBalanceCardProps {
 export default function OpNetBalanceCard(props: OpNetBalanceCardProps) {
     const { tokenBalance, onClick } = props;
     const balance = new BigNumber(bigIntToDecimal(tokenBalance.amount, tokenBalance.divisibility)); //runesUtils.toDecimalNumber(tokenBalance.amount, tokenBalance.divisibility);
-    const str = balance.toPrecision();
+    const truncatedBalance = Math.floor(Number(balance) * 1e5) / 1e5;
+    const str =
+        Number(balance) > 0
+            ? truncatedBalance.toLocaleString('en-US', { minimumFractionDigits: 5, maximumFractionDigits: 5 })
+            : '0';
 
     return (
         <Card

--- a/src/ui/pages/Account/SwitchKeyringScreen.tsx
+++ b/src/ui/pages/Account/SwitchKeyringScreen.tsx
@@ -117,7 +117,8 @@ export function MyItem({ keyring, autoNav }: MyItemProps, ref) {
                     <Column
                         style={{
                             backgroundColor: colors.black,
-                            width: 180,
+                            width: 250,
+                            top: 32,
                             position: 'absolute',
                             right: 0,
                             padding: 5,

--- a/src/ui/pages/Main/SettingsTabScreen.tsx
+++ b/src/ui/pages/Main/SettingsTabScreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { ADDRESS_TYPES, DISCORD_URL, GITHUB_URL, KEYRING_TYPE, TELEGRAM_URL, TWITTER_URL } from '@/shared/constant';
+import { ADDRESS_TYPES, GITHUB_URL, KEYRING_TYPE, TELEGRAM_URL, TWITTER_URL } from '@/shared/constant';
 import { Card, Column, Content, Footer, Header, Layout, Row, Text } from '@/ui/components';
 import { useTools } from '@/ui/components/ActionComponent';
 import { Button } from '@/ui/components/Button';
@@ -237,15 +237,6 @@ export default function SettingsTabScreen() {
                         })}
                     </div>
                     <Row justifyCenter gap="xl" mt="lg">
-                        <Icon
-                            icon="discord"
-                            size={fontSizes.iconMiddle}
-                            color="textDim"
-                            onClick={() => {
-                                window.open(DISCORD_URL);
-                            }}
-                        />
-
                         <Icon
                             icon="twitter"
                             size={fontSizes.iconMiddle}

--- a/src/ui/pages/Main/WalletTabScreen/OPNetList.tsx
+++ b/src/ui/pages/Main/WalletTabScreen/OPNetList.tsx
@@ -215,7 +215,11 @@ export function OPNetList() {
                         text="Deploy"
                         icon={'pencil'}
                         preset="fontsmall"
-                        onClick={() => navigate('DeployContract', {})}></Button>
+                        onClick={() => {
+                            chrome.tabs.create({
+                                url: chrome.runtime.getURL('/index.html#/opnet/deploy-contract')
+                            });
+                        }}></Button>
                 </Row>
             </BaseView>
             {importTokenBool && (

--- a/src/ui/pages/Main/WalletTabScreen/index.tsx
+++ b/src/ui/pages/Main/WalletTabScreen/index.tsx
@@ -57,7 +57,7 @@ export default function WalletTabScreen() {
     const currentKeyring = useCurrentKeyring();
     const currentAccount = useCurrentAccount();
     const balanceValue = useMemo(() => {
-        return accountBalance.amount;
+        return Math.floor(Number(accountBalance.amount) * 1e5) / 1e5;
     }, [accountBalance.amount]);
 
     const wallet = useWallet();

--- a/src/ui/pages/OpNet/DeployContract.tsx
+++ b/src/ui/pages/OpNet/DeployContract.tsx
@@ -4,18 +4,18 @@ import { useLocation } from 'react-router-dom';
 import { Account, OpNetBalance } from '@/shared/types';
 import { Button, Column, Content, Header, Layout, Text } from '@/ui/components';
 import { useTools } from '@/ui/components/ActionComponent';
+import { FeeRateBar } from '@/ui/components/FeeRateBar';
 import { useCurrentAccount } from '@/ui/state/accounts/hooks';
 import { useCurrentKeyring } from '@/ui/state/keyrings/hooks';
 
 import { useNavigate } from '../MainRoute';
-import { FeeRateBar } from '@/ui/components/FeeRateBar';
 
 interface ItemData {
     key: string;
     account?: Account;
 }
 
-export default function WrapBitcoinOpnet() {
+export default function DeployContractOpnet() {
     const { state } = useLocation();
     const props = state as {
         OpNetBalance: OpNetBalance;
@@ -62,7 +62,7 @@ export default function WrapBitcoinOpnet() {
                 onBack={() => {
                     window.history.go(-1);
                 }}
-                title={'deploy Contract'}
+                title={'Deploy Contract'}
             />
             <Content>
                 <Text text="Upload Contract" color="textDim" />

--- a/src/ui/pages/OpNet/SwapToken.tsx
+++ b/src/ui/pages/OpNet/SwapToken.tsx
@@ -328,7 +328,7 @@ export default function Swap() {
                                         symbol: selectedOption?.symbol
                                     },
                                     {
-                                        amount: expandToDecimals(outputAmount, selectedOption?.divisibility ?? 8),
+                                        amount: expandToDecimals(outputAmount, selectedOptionOutput?.divisibility ?? 8),
                                         divisibility: selectedOptionOutput?.divisibility,
                                         spacedRune: selectedOptionOutput?.name,
                                         symbol: selectedOptionOutput?.symbol

--- a/src/ui/pages/Wallet/TxOpnetConfirmScreen.tsx
+++ b/src/ui/pages/Wallet/TxOpnetConfirmScreen.tsx
@@ -20,6 +20,7 @@ import { Button, Card, Column, Content, Footer, Header, Layout, Row, Text } from
 import { ContextType, useTools } from '@/ui/components/ActionComponent';
 import { BottomModal } from '@/ui/components/BottomModal';
 import RunesPreviewCard from '@/ui/components/RunesPreviewCard';
+import { useBTCUnit } from '@/ui/state/settings/hooks';
 import { useLocationState, useWallet } from '@/ui/utils';
 import { LoadingOutlined } from '@ant-design/icons';
 import { ABIDataTypes, Address, BinaryWriter } from '@btc-vision/bsi-binary';
@@ -113,6 +114,8 @@ export default function TxOpnetConfirmScreen() {
     const [_unwrapUseAmount, setUnWrapAmount] = useState<bigint>(0n);
     const { rawTxInfo } = useLocationState<LocationState>();
 
+    const btcUnit = useBTCUnit();
+
     const handleCancel = () => {
         window.history.go(-1);
     };
@@ -153,7 +156,7 @@ export default function TxOpnetConfirmScreen() {
 
                 const nextUTXO = finalUnwrapTx.utxos;
                 localStorage.setItem('nextUTXO', JSON.stringify(nextUTXO));
-                tools.toastSuccess('"You have successfully un-wrapped your Bitcoin"');
+                tools.toastSuccess(`You have successfully un-wrapped your wBTC`);
                 navigate('TxSuccessScreen', { txid: unwrapTransaction.result });
             };
             void completeUnwrap();
@@ -222,7 +225,7 @@ export default function TxOpnetConfirmScreen() {
                 tools.toastError('Could not broadcast second transaction');
             }
 
-            tools.toastSuccess(`"You have successfully transferred ${amountToSend} Bitcoin"`);
+            tools.toastSuccess(`You have successfully transferred ${amountToSend} ${btcUnit}`);
             // Store the next UTXO in localStorage
             const nextUTXO = finalTx[2];
             localStorage.setItem('nextUTXO', JSON.stringify(nextUTXO));
@@ -333,7 +336,7 @@ export default function TxOpnetConfirmScreen() {
             const nextUTXO = finalTx.utxos;
             localStorage.setItem('nextUTXO', JSON.stringify(nextUTXO));
             const wrappedAmount = bigIntToDecimal(wrapAmount, 8).toString();
-            tools.toastSuccess(`"You have successfully wrapped ${wrappedAmount} Bitcoin"`);
+            tools.toastSuccess(`You have successfully wrapped ${wrappedAmount} ${btcUnit}`);
             navigate('TxSuccessScreen', { txid: secondTxBroadcast.result });
         } catch (e) {
             const msg = getErrorMessage(e as Error);
@@ -573,7 +576,7 @@ export default function TxOpnetConfirmScreen() {
         }
 
         const stakeAmount = bigIntToDecimal(amountToSend, 8).toString();
-        tools.toastSuccess(`You have successfully staked ${stakeAmount} WBTC`);
+        tools.toastSuccess(`You have successfully staked ${stakeAmount} wBTC`);
         const nextUTXO = sendTransact[2];
         localStorage.setItem('nextUTXO', JSON.stringify(nextUTXO));
         navigate('TxSuccessScreen', { txid: secondTransaction.result });
@@ -643,7 +646,7 @@ export default function TxOpnetConfirmScreen() {
         }
 
         const unstakeAmount = bigIntToDecimal(amountToSend, 8).toString();
-        tools.toastSuccess(`You have successfully un-staked ${unstakeAmount} WBTC`);
+        tools.toastSuccess(`You have successfully un-staked ${unstakeAmount} wBTC`);
 
         const nextUTXO = sendTransact[2];
         localStorage.setItem('nextUTXO', JSON.stringify(nextUTXO));
@@ -846,7 +849,7 @@ export default function TxOpnetConfirmScreen() {
 
         const claimAmount = bigIntToDecimal(amountToSend, 8).toString();
 
-        tools.toastSuccess(`You have successfully claimed ${claimAmount} WBTC`);
+        tools.toastSuccess(`You have successfully claimed ${claimAmount} wBTC`);
         const nextUTXO = sendTransact[2];
         localStorage.setItem('nextUTXO', JSON.stringify(nextUTXO));
         navigate('TxSuccessScreen', { txid: seconfTransaction.result });
@@ -930,10 +933,10 @@ export default function TxOpnetConfirmScreen() {
             tools.toastError('Could not broadcast first transaction');
             return;
         } else {
-            const amountA = bigIntToDecimal(rawTxInfo.inputAmount[0], rawTxInfo.opneTokens[0].divisibility).toString();
-            const amountB = bigIntToDecimal(rawTxInfo.inputAmount[1], rawTxInfo.opneTokens[1].divisibility).toString();
+            const amountA = Number(rawTxInfo.inputAmount[0]).toLocaleString();
+            const amountB = Number(rawTxInfo.inputAmount[1]).toLocaleString();
             tools.toastSuccess(
-                `"You have successfully swapped ${amountA} ${rawTxInfo.opneTokens[0].symbol} for ${amountB}  ${rawTxInfo.opneTokens[1].symbol}"`
+                `You have successfully swapped ${amountA} ${rawTxInfo.opneTokens[0].symbol} for ${amountB}  ${rawTxInfo.opneTokens[1].symbol}`
             );
             const nextUTXO = sendTransact[2];
             localStorage.setItem('nextUTXO', JSON.stringify(nextUTXO));
@@ -1040,10 +1043,8 @@ export default function TxOpnetConfirmScreen() {
                 return;
             }
 
-            const amountA = bigIntToDecimal(rawTxInfo.inputAmount, rawTxInfo.opneTokens[0].divisibility).toString();
-            tools.toastSuccess(
-                `"You have successfully transferred ${amountA} ${rawTxInfo.opneTokens[0].symbol} to ${rawTxInfo.address}}"`
-            );
+            const amountA = Number(rawTxInfo.inputAmount).toLocaleString();
+            tools.toastSuccess(`You have successfully transferred ${amountA} ${rawTxInfo.opneTokens[0].symbol}`);
 
             localStorage.setItem('nextUTXO', JSON.stringify(sendTransact.nextUTXOs));
             navigate('TxSuccessScreen', { txid: firstTransaction.result });


### PR DESCRIPTION
### Summary of Changes:
- Updated GitHub, Twitter, and Telegram links in settings, and removed Discord link
- Improved balance formatting: displayed in en-US format with 5 decimal places, using `Math.floor` to prevent rounding
- Increased the width of the wallet settings popup in HD Wallet#𝑥
- Deploy Contract now opens in a new tab to avoid window closure when uploading `.wasm` files
- Fixed amount display issue during swap preview
- Fixed success messages for transactions (wrap, swap, etc.) by correctly displaying amount and currency using `useBTCUnit()` in `TxOpnetConfirmScreen.tsx`