### PR TITLE
Fix: Revert Controller Structure, Add Error Handling in UTXO Management & Refine Deployment Logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "opwallet",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "private": true,
     "homepage": "https://github.com/unisat-wallet/extension#readme",
     "bugs": {

--- a/src/background/controller/provider/controller.ts
+++ b/src/background/controller/provider/controller.ts
@@ -365,7 +365,7 @@ class ProviderController extends BaseController {
     getBitcoinUtxos = async () => {
         const account = await wallet.getCurrentAccount();
         if (!account) return [];
-        const utxos = await Web3API.getUTXOs([account.address]);
+        const utxos = await wallet.getBTCUtxos();
         return utxos;
     };
 }

--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -1106,7 +1106,7 @@ export class WalletController extends BaseController {
             };
         });*/
 
-        const utxos = await Web3API.getUTXOs([account.address], 1000000000000000n);
+        const utxos = await Web3API.getUTXOs([account.address]);
 
         return utxos.map((utxoOpnet) => {
             return {

--- a/src/background/controller/wallet.ts
+++ b/src/background/controller/wallet.ts
@@ -1,4 +1,4 @@
-import { BroadcastedTransaction, UTXOs } from 'opnet';
+import { BroadcastedTransaction } from 'opnet';
 
 import {
     contactBookService,
@@ -1082,6 +1082,47 @@ export class WalletController extends BaseController {
         return preferenceService.getChainType();
     };
 
+    getBTCUtxos = async () => {
+        // getBTCAccount
+        const account = preferenceService.getCurrentAccount();
+        if (!account) throw new Error('no current account');
+
+        /*let utxos = await openapiService.getBTCUtxos(account.address);
+
+        if (checkAddressFlag(openapiService.addressFlag, AddressFlagType.CONFIRMED_UTXO_MODE)) {
+            utxos = utxos.filter((v) => (v as any).height !== UNCONFIRMED_HEIGHT);
+        }
+
+        const btcUtxos = utxos.map((v) => {
+            return {
+                txid: v.txid,
+                vout: v.vout,
+                satoshis: v.satoshis,
+                scriptPk: v.scriptPk,
+                addressType: v.addressType,
+                pubkey: account.pubkey,
+                inscriptions: v.inscriptions,
+                atomicals: v.atomicals
+            };
+        });*/
+
+        const utxos = await Web3API.getUTXOs([account.address], 1000000000000000n);
+
+        return utxos.map((utxoOpnet) => {
+            return {
+                runes: [],
+                txid: utxoOpnet.transactionId,
+                vout: utxoOpnet.outputIndex,
+                satoshis: Number(utxoOpnet.value),
+                scriptPk: utxoOpnet.scriptPubKey.hex,
+                addressType: AddressType.P2PKH,
+                pubkey: account.pubkey,
+                inscriptions: [],
+                atomicals: []
+            };
+        });
+    };
+
     getUnavailableUtxos = async () => {
         /*const account = preferenceService.getCurrentAccount();
         if (!account) throw new Error('no current account');
@@ -1127,7 +1168,7 @@ export class WalletController extends BaseController {
         amount: number;
         feeRate: number;
         enableRBF: boolean;
-        btcUtxos?: UTXOs;
+        btcUtxos?: UnspentOutput[];
         memo?: string;
         memos?: string[];
     }) => {
@@ -1137,7 +1178,7 @@ export class WalletController extends BaseController {
         const networkType = this.getNetworkType();
 
         if (!btcUtxos) {
-            btcUtxos = await Web3API.getUTXOs([account.address], BigInt(amount));
+            btcUtxos = await this.getBTCUtxos();
         }
 
         if (btcUtxos.length == 0) {
@@ -1149,7 +1190,7 @@ export class WalletController extends BaseController {
         }
 
         const { psbt, toSignInputs } = await txHelpers.sendBTC({
-            btcUtxos,
+            btcUtxos: btcUtxos,
             tos: [{ address: to, satoshis: amount }],
             networkType,
             changeAddress: account.address,
@@ -1174,7 +1215,7 @@ export class WalletController extends BaseController {
         to: string;
         feeRate: number;
         enableRBF: boolean;
-        btcUtxos?: UTXOs;
+        btcUtxos?: UnspentOutput[];
     }) => {
         const account = preferenceService.getCurrentAccount();
         if (!account) throw new Error('no current account');
@@ -1182,7 +1223,7 @@ export class WalletController extends BaseController {
         const networkType = this.getNetworkType();
 
         if (!btcUtxos) {
-            btcUtxos = await Web3API.getUTXOs([account.address]);
+            btcUtxos = await this.getBTCUtxos();
         }
 
         if (btcUtxos.length == 0) {
@@ -1216,7 +1257,7 @@ export class WalletController extends BaseController {
         feeRate: number;
         outputValue?: number;
         enableRBF: boolean;
-        btcUtxos?: UTXOs;
+        btcUtxos?: UnspentOutput[];
     }) => {
         const account = preferenceService.getCurrentAccount();
         if (!account) throw new Error('no current account');
@@ -1235,7 +1276,7 @@ export class WalletController extends BaseController {
         const assetUtxo = Object.assign(utxo, { pubkey: account.pubkey });
 
         if (!btcUtxos) {
-            btcUtxos = await Web3API.getUTXOs([account.address]);
+            btcUtxos = await this.getBTCUtxos();
         }
 
         if (btcUtxos.length == 0) {
@@ -1272,7 +1313,7 @@ export class WalletController extends BaseController {
         utxos: UTXO[];
         feeRate: number;
         enableRBF: boolean;
-        btcUtxos?: UTXOs;
+        btcUtxos?: UnspentOutput[];
     }) => {
         const account = preferenceService.getCurrentAccount();
         if (!account) throw new Error('no current account');
@@ -1301,7 +1342,7 @@ export class WalletController extends BaseController {
         });
 
         if (!btcUtxos) {
-            btcUtxos = await Web3API.getUTXOs([account.address]);
+            btcUtxos = await this.getBTCUtxos();
         }
 
         if (btcUtxos.length == 0) {
@@ -1337,7 +1378,7 @@ export class WalletController extends BaseController {
         feeRate: number;
         outputValue: number;
         enableRBF: boolean;
-        btcUtxos?: UTXOs;
+        btcUtxos?: UnspentOutput[];
     }) => {
         const account = preferenceService.getCurrentAccount();
         if (!account) throw new Error('no current account');
@@ -1352,7 +1393,7 @@ export class WalletController extends BaseController {
         const assetUtxo = Object.assign(utxo, { pubkey: account.pubkey });
 
         if (!btcUtxos) {
-            btcUtxos = await Web3API.getUTXOs([account.address]);
+            btcUtxos = await this.getBTCUtxos();
         }
 
         const { psbt, toSignInputs, splitedCount } = await txHelpers.splitInscriptionUtxo({
@@ -1563,7 +1604,7 @@ export class WalletController extends BaseController {
     };
 
     getAddressUtxo = async (address: string) => {
-        return await Web3API.getUTXOs([address]);
+        return await openapiService.getBTCUtxos(address);
     };
 
     setRecentConnectedSites = (sites: ConnectedSite[]) => {
@@ -1884,7 +1925,7 @@ export class WalletController extends BaseController {
         atomicalId: string;
         feeRate: number;
         enableRBF: boolean;
-        btcUtxos?: UTXOs;
+        btcUtxos?: UnspentOutput[];
     }) => {
         const account = preferenceService.getCurrentAccount();
         if (!account) throw new Error('no current account');
@@ -1903,7 +1944,7 @@ export class WalletController extends BaseController {
         const assetUtxo = Object.assign(utxo, { pubkey: account.pubkey });
 
         if (!btcUtxos) {
-            btcUtxos = await Web3API.getUTXOs([account.address]);
+            btcUtxos = await this.getBTCUtxos();
         }
 
         if (btcUtxos.length == 0) {
@@ -1940,7 +1981,7 @@ export class WalletController extends BaseController {
         amount: number;
         feeRate: number;
         enableRBF: boolean;
-        btcUtxos?: UTXOs;
+        btcUtxos?: UnspentOutput[];
         assetUtxos?: UnspentOutput[];
     }) => {
         const account = preferenceService.getCurrentAccount();
@@ -1953,7 +1994,7 @@ export class WalletController extends BaseController {
         }
 
         if (!btcUtxos) {
-            btcUtxos = await Web3API.getUTXOs([account.address]);
+            btcUtxos = await this.getBTCUtxos();
         }
 
         const changeDust = getAddressUtxoDust(account.address);
@@ -2153,7 +2194,7 @@ export class WalletController extends BaseController {
         runeAmount: string;
         feeRate: number;
         enableRBF: boolean;
-        btcUtxos?: UTXOs;
+        btcUtxos?: UnspentOutput[];
         assetUtxos?: UnspentOutput[];
         outputValue?: number;
     }) => {
@@ -2212,7 +2253,7 @@ export class WalletController extends BaseController {
         assetUtxos = _assetUtxos;
 
         if (!btcUtxos) {
-            btcUtxos = await Web3API.getUTXOs([account.address]);
+            btcUtxos = await this.getBTCUtxos();
         }
 
         const { psbt, toSignInputs } = await txHelpers.sendRunes({

--- a/src/shared/utils/message/portMessage.ts
+++ b/src/shared/utils/message/portMessage.ts
@@ -51,11 +51,11 @@ class PortMessage extends Message {
     send = (type: string, data: RequestData) => {
         if (!this.port) return;
 
-        //try {
-        this.port.postMessage({ _type_: `${this._EVENT_PRE}${type}`, data });
-        //} catch (e) {
-        // DO NOTHING BUT CATCH THIS ERROR
-        //}
+        try {
+            this.port.postMessage({ _type_: `${this._EVENT_PRE}${type}`, data });
+        } catch (e) {
+            //
+        }
     };
 
     dispose = () => {

--- a/src/shared/web3/Web3API.ts
+++ b/src/shared/web3/Web3API.ts
@@ -251,16 +251,18 @@ class Web3API {
         let utxos: UTXOs = [];
 
         for (const address of addresses) {
-            if (!requiredAmount) {
-                utxos = await this.provider.utxoManager.getUTXOs({ address, optimize: false });
-            } else {
-                utxos = await this.provider.utxoManager.getUTXOsForAmount({
-                    address,
-                    amount: requiredAmount,
-                    optimize: false,
-                    mergePendingUTXOs: true,
-                    filterSpentUTXOs: true
-                });
+            try {
+                if (!requiredAmount) {
+                    utxos = await this.provider.utxoManager.getUTXOs({ address, optimize: false });
+                } else {
+                    utxos = await this.provider.utxoManager.getUTXOsForAmount({
+                        address,
+                        amount: requiredAmount,
+                        optimize: false
+                    });
+                }
+            } catch (e) {
+                //
             }
 
             if (utxos.length) {

--- a/src/ui/pages/Wallet/TxOpnetConfirmScreen.tsx
+++ b/src/ui/pages/Wallet/TxOpnetConfirmScreen.tsx
@@ -1062,7 +1062,7 @@ export default function TxOpnetConfirmScreen() {
     const deployContract = async () => {
         try {
             const foundObject = rawTxInfo.items.find(
-                (obj) => obj.account && obj.account.address === rawTxInfo.account.address
+                (obj: { account: Account }) => obj.account && obj.account.address === rawTxInfo.account.address
             );
 
             const wifWallet = await wallet.getInternalPrivateKey(foundObject?.account as Account);
@@ -1070,7 +1070,7 @@ export default function TxOpnetConfirmScreen() {
 
             let utxos: UTXO[] = [];
             if (!useNextUTXO) {
-                utxos = await Web3API.getUTXOs(walletGet.addresses, expandToDecimals(0.08, 8));
+                utxos = await Web3API.getUTXOs(walletGet.addresses, expandToDecimals(0.008, 8));
             } else {
                 const storedUTXO = localStorage.getItem('nextUTXO');
                 utxos = storedUTXO
@@ -1140,6 +1140,7 @@ export default function TxOpnetConfirmScreen() {
             }
         } catch (e) {
             console.log(e);
+            tools.toastError(`Error: ${e}`);
             setDisabled(false);
             setDisabled(false);
         }


### PR DESCRIPTION
### Description

- Reverts `wallet.ts` and `controller.ts` to the previous structure to ensure full compatibility with Ordinals.
- Adds `try/catch` error handling in the `getUTXOsForAddresses` function to prevent the entire function from failing when it doesn't have the required amount in UTXO.
- Removes one minor console error for cleaner logs.
- Fixes `getUTXOs` call in the `getBTCUtxos()` function inside `wallet.ts` to avoid passing a high UTXO amount that could cause failures:  
  - Updated from `const utxos = await Web3API.getUTXOs([account.address], 1000000000000000n);`  
  - To `const utxos = await Web3API.getUTXOs([account.address]);`
- Updates `TxOpnetConfirmScreen`:
  - Adjusts required UTXO amount from `0.08` to `0.008` for deployment.
  - Includes `tools.toastError()` in the catch block of the `deployContract` function to display error details to the user.