### PR TITLE
bump to 1.0.19: Switch to regtest by default, OP_NET updates, and min…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "opwallet",
-    "version": "1.0.18",
+    "version": "1.0.19",
     "private": true,
     "homepage": "https://github.com/unisat-wallet/extension#readme",
     "bugs": {

--- a/src/background/service/preference.ts
+++ b/src/background/service/preference.ts
@@ -118,8 +118,8 @@ class PreferenceService {
                 firstOpen: false,
                 currency: 'USD',
                 addressType: AddressType.P2WPKH,
-                networkType: NetworkType.MAINNET,
-                chainType: ChainType.BITCOIN_MAINNET,
+                networkType: NetworkType.REGTEST, // TODO: To change to mainnet when mainnet is ready
+                chainType: ChainType.BITCOIN_REGTEST, // TODO: To change to mainnet when mainnet is ready
                 keyringAlianNames: {},
                 accountAlianNames: {},
                 uiCachedData: {},

--- a/src/ui/components/NavTabBar/index.tsx
+++ b/src/ui/components/NavTabBar/index.tsx
@@ -9,10 +9,12 @@ import { Grid } from '../Grid';
 import { Icon, IconTypes } from '../Icon';
 
 export function NavTabBar({ tab }: { tab: TabOption }) {
+    const isOPNETonly = localStorage.getItem('selectionUser') === 'opnet-only';
+
     return (
-        <Grid columns={4} style={{ width: '100%', height: '67.5px', backgroundColor: colors.bg2 }}>
+        <Grid columns={isOPNETonly ? 3 : 4} style={{ width: '100%', height: '67.5px', backgroundColor: colors.bg2 }}>
             <TabButton tabName="home" icon="wallet" isActive={tab === 'home'} />
-            <TabButton tabName="mint" icon="compass" isActive={tab === 'mint'} />
+            {!isOPNETonly && <TabButton tabName="mint" icon="compass" isActive={tab === 'mint'} />}
             <TabButton tabName="app" icon="grid" isActive={tab === 'app'} />
             <TabButton tabName="settings" icon="settings" isActive={tab === 'settings'} />
         </Grid>

--- a/src/ui/components/NoticePopover/index.tsx
+++ b/src/ui/components/NoticePopover/index.tsx
@@ -11,18 +11,17 @@ import { Popover } from '../Popover';
 import { Row } from '../Row';
 import { Text } from '../Text';
 
-export const NoticePopover = ({ onClose }: { onClose: () => void }) => {
-    const [checked1, setChecked1] = useState(false);
-    const [checked2, setChecked2] = useState(false);
-
-    const [enable, setEnable] = useState(false);
+export const NoticePopover = ({ onClose }: { onClose: (mode: 'opnet-only' | 'opnet-with-standards') => void }) => {
+    const [opNetOnly, setOpNetOnly] = useState(true);
     const [coolDown, setCoolDown] = useState(3);
+    const [enable, setEnable] = useState(false);
 
     useEffect(() => {
         if (coolDown > 0) {
-            setTimeout(() => {
-                setCoolDown(coolDown - 1);
-            }, 3000);
+            const timer = setTimeout(() => {
+                setCoolDown((prev) => prev - 1);
+            }, 1000);
+            return () => clearTimeout(timer);
         } else {
             setEnable(true);
         }
@@ -31,45 +30,58 @@ export const NoticePopover = ({ onClose }: { onClose: () => void }) => {
     return (
         <Popover>
             <Column justifyCenter itemsCenter>
-                <Text text="Compatibility Tips" preset="title-bold" />
-                <Icon icon={'info'} color={'icon_yellow'} size={57} />
+                <Text text="Setup Preferences" preset="title-bold" />
+                <Icon
+                    icon={'settings'}
+                    color={'icon_yellow'}
+                    size={35}
+                    style={{
+                        marginBottom: 12
+                    }}
+                />
 
-                <Column gap="zero">
-                    <Text text={'Please be aware that:'} preset={'bold'} />
+                <Column
+                    gap="zero"
+                    style={{
+                        marginBottom: 20
+                    }}>
+                    <Text text={'Choose your setup:'} preset={'bold'} />
                     <div style={{ marginTop: 8 }}>
-                        <Checkbox
-                            checked={checked1}
-                            onChange={(e) => {
-                                setChecked1(e.target.checked);
-                            }}>
+                        <Checkbox checked={opNetOnly} onChange={(e) => setOpNetOnly(true)}>
                             <div style={{ fontSize: fontSizes.sm }}>
-                                for Ordinals assets, <span style={{ color: '#EBB94C' }}>Rare sats </span>are not
-                                supported.
+                                Use <span style={{ color: '#EBB94C' }}>OP_NET only</span>, without support for other
+                                standards such as Ordinals, Atomicals or Runes.
                             </div>
                         </Checkbox>
                     </div>
                     <Row style={{ borderTopWidth: 1, borderColor: colors.border }} my="md" />
 
                     <div>
-                        <Checkbox checked={checked2} onChange={(e) => setChecked2(e.target.checked)}>
+                        <Checkbox checked={!opNetOnly} onChange={(e) => setOpNetOnly(false)}>
                             <div style={{ fontSize: fontSizes.sm }}>
-                                for Atomicals assets, <span style={{ color: '#EBB94C' }}>Non-ARC20</span> are not
-                                supported yet.
+                                Enable support for additional standards (e.g.,{' '}
+                                <span style={{ color: '#EBB94C' }}>Ordinals, Atomicals, Runes</span>) along with OP_NET.
                             </div>
                         </Checkbox>
                     </div>
                 </Column>
 
+                <Text
+                    text="You can change this setting later in the preferences if needed."
+                    preset="default"
+                    style={{ marginBottom: 12, textAlign: 'center' }}
+                />
+
                 <Row full>
                     <Button
                         text={coolDown > 0 ? `OK (${coolDown}s)` : 'OK'}
                         preset="primary"
-                        disabled={!checked1 || !checked2}
+                        disabled={!enable}
                         full
                         onClick={() => {
                             if (!enable) return;
                             if (onClose) {
-                                onClose();
+                                onClose(opNetOnly ? 'opnet-only' : 'opnet-with-standards');
                             }
                         }}
                     />

--- a/src/ui/pages/Main/WalletTabScreen/index.tsx
+++ b/src/ui/pages/Main/WalletTabScreen/index.tsx
@@ -14,6 +14,7 @@ import { NavTabBar } from '@/ui/components/NavTabBar';
 import { NoticePopover } from '@/ui/components/NoticePopover';
 import { UpgradePopover } from '@/ui/components/UpgradePopover';
 import { getCurrentTab } from '@/ui/features/browser/tabs';
+import { BtcDisplay } from '@/ui/pages/Main/WalletTabScreen/components/BtcDisplay';
 import { useAccountBalance, useAddressSummary, useCurrentAccount } from '@/ui/state/accounts/hooks';
 import { accountActions } from '@/ui/state/accounts/reducer';
 import { useAppDispatch } from '@/ui/state/hooks';
@@ -41,7 +42,6 @@ import { AtomicalsTab } from './AtomicalsTab';
 import { OPNetList } from './OPNetList';
 import { OrdinalsTab } from './OrdinalsTab';
 import { RunesList } from './RunesList';
-import { BtcDisplay } from '@/ui/pages/Main/WalletTabScreen/components/BtcDisplay';
 
 const $noBreakStyle: CSSProperties = {
     whiteSpace: 'nowrap',
@@ -143,6 +143,8 @@ export default function WalletTabScreen() {
         };
         void run();
     }, []);
+
+    const isOPNETonly = localStorage.getItem('selectionUser') === 'opnet-only';
 
     let tabItems = [
         {
@@ -266,68 +268,68 @@ export default function WalletTabScreen() {
                         </Column>
                     )}
 
-          <Tooltip
-            placement={'bottom'}
-            title={
-              !loadingFetch ? (
-                <>
-                  <Row justifyBetween>
-                    <span style={$noBreakStyle}>{'Available '}</span>
-                    <span style={$noBreakStyle}>{` ${availableAmount} ${btcUnit}`}</span>
-                  </Row>
-                  <Row justifyBetween>
-                    <span style={$noBreakStyle}>{'Unavailable '}</span>
-                    <span style={$noBreakStyle}>{` ${unavailableAmount} ${btcUnit}`}</span>
-                  </Row>
-                  <Row justifyBetween>
-                    <span style={$noBreakStyle}>{'Total '}</span>
-                    <span style={$noBreakStyle}>{` ${totalAmount} ${btcUnit}`}</span>
-                  </Row>
-                </>
-              ) : (
-                <>
-                  <Row justifyBetween>
-                    <span style={$noBreakStyle}>{'Available '}</span>
-                    <span style={$noBreakStyle}>{'loading...'}</span>
-                  </Row>
-                  <Row justifyBetween>
-                    <span style={$noBreakStyle}>{'Unavailable '}</span>
-                    <span style={$noBreakStyle}>{'loading...'}</span>
-                  </Row>
-                  <Row justifyBetween>
-                    <span style={$noBreakStyle}>{'Total '}</span>
-                    <span style={$noBreakStyle}>{` ${totalAmount} ${btcUnit}`}</span>
-                  </Row>
-                </>
-              )
-            }
-            onOpenChange={(v) => {
-              if (!ref.current.fetchedUtxo[currentAccount.address]) {
-                ref.current.fetchedUtxo[currentAccount.address] = { loading: true };
-                setLoadingFetch(true);
-                fetchUtxos().finally(() => {
-                  ref.current.fetchedUtxo[currentAccount.address].loading = false;
-                  setLoadingFetch(false);
-                });
-              }
-            }}
-            overlayStyle={{
-              fontSize: fontSizes.xs
-            }}>
-              <div>
-                  <Text text={'TOTAL BALANCE'} textCenter color="textDim" />
-                  <BtcDisplay balance={balanceValue} />
-              </div>
-          </Tooltip>
-          <BtcUsd
-            sats={amountToSatoshis(balanceValue)}
-            textCenter
-            size={'md'}
-            style={{
-              marginTop: -16,
-              marginBottom: -8
-            }}
-          />
+                    <Tooltip
+                        placement={'bottom'}
+                        title={
+                            !loadingFetch ? (
+                                <>
+                                    <Row justifyBetween>
+                                        <span style={$noBreakStyle}>{'Available '}</span>
+                                        <span style={$noBreakStyle}>{` ${availableAmount} ${btcUnit}`}</span>
+                                    </Row>
+                                    <Row justifyBetween>
+                                        <span style={$noBreakStyle}>{'Unavailable '}</span>
+                                        <span style={$noBreakStyle}>{` ${unavailableAmount} ${btcUnit}`}</span>
+                                    </Row>
+                                    <Row justifyBetween>
+                                        <span style={$noBreakStyle}>{'Total '}</span>
+                                        <span style={$noBreakStyle}>{` ${totalAmount} ${btcUnit}`}</span>
+                                    </Row>
+                                </>
+                            ) : (
+                                <>
+                                    <Row justifyBetween>
+                                        <span style={$noBreakStyle}>{'Available '}</span>
+                                        <span style={$noBreakStyle}>{'loading...'}</span>
+                                    </Row>
+                                    <Row justifyBetween>
+                                        <span style={$noBreakStyle}>{'Unavailable '}</span>
+                                        <span style={$noBreakStyle}>{'loading...'}</span>
+                                    </Row>
+                                    <Row justifyBetween>
+                                        <span style={$noBreakStyle}>{'Total '}</span>
+                                        <span style={$noBreakStyle}>{` ${totalAmount} ${btcUnit}`}</span>
+                                    </Row>
+                                </>
+                            )
+                        }
+                        onOpenChange={(v) => {
+                            if (!ref.current.fetchedUtxo[currentAccount.address]) {
+                                ref.current.fetchedUtxo[currentAccount.address] = { loading: true };
+                                setLoadingFetch(true);
+                                fetchUtxos().finally(() => {
+                                    ref.current.fetchedUtxo[currentAccount.address].loading = false;
+                                    setLoadingFetch(false);
+                                });
+                            }
+                        }}
+                        overlayStyle={{
+                            fontSize: fontSizes.xs
+                        }}>
+                        <div>
+                            <Text text={'TOTAL BALANCE'} textCenter color="textDim" />
+                            <BtcDisplay balance={balanceValue} />
+                        </div>
+                    </Tooltip>
+                    <BtcUsd
+                        sats={amountToSatoshis(balanceValue)}
+                        textCenter
+                        size={'md'}
+                        style={{
+                            marginTop: -16,
+                            marginBottom: -8
+                        }}
+                    />
 
                     <Row itemsCenter justifyCenter>
                         <AddressBar />
@@ -399,23 +401,28 @@ export default function WalletTabScreen() {
                         )}
                     </Row>
 
-                    <Tabs
-                        size={'small'}
-                        defaultActiveKey={finalAssetTabKey as unknown as string}
-                        activeKey={finalAssetTabKey as unknown as string}
-                        items={tabItems as unknown as any[]}
-                        onTabClick={(key) => {
-                            dispatch(uiActions.updateAssetTabScreen({ assetTabKey: key as unknown as AssetTabKey }));
-                        }}
-                    />
-
-                    {/*{tabItems[assetTabKey].children}*/}
+                    {isOPNETonly ? (
+                        <>{tabItems[assetTabKey].children}</>
+                    ) : (
+                        <Tabs
+                            size={'small'}
+                            defaultActiveKey={finalAssetTabKey as unknown as string}
+                            activeKey={finalAssetTabKey as unknown as string}
+                            items={tabItems as unknown as any[]}
+                            onTabClick={(key) => {
+                                dispatch(
+                                    uiActions.updateAssetTabScreen({ assetTabKey: key as unknown as AssetTabKey })
+                                );
+                            }}
+                        />
+                    )}
                 </Column>
                 {showSafeNotice && (
                     <NoticePopover
-                        onClose={() => {
+                        onClose={(selection) => {
                             wallet.setShowSafeNotice(false);
                             setShowSafeNotice(false);
+                            localStorage.setItem('selectionUser', selection);
                         }}
                     />
                 )}

--- a/src/ui/pages/Main/WelcomeScreen.tsx
+++ b/src/ui/pages/Main/WelcomeScreen.tsx
@@ -25,7 +25,7 @@ export default function WelcomeScreen() {
                     <Column gap="xl" mt="xxl">
                         <Text
                             text={
-                                "Inscribe and store your inscriptions in the world's first Open Source Chrome wallet for Ordinals!"
+                                'A browser-based extension that allows you to manage your tokens and interact with applications built on the OP_NET metaprotocol.'
                             }
                             preset="sub"
                             textCenter

--- a/src/ui/pages/Settings/AddressTypeScreen.tsx
+++ b/src/ui/pages/Settings/AddressTypeScreen.tsx
@@ -8,7 +8,7 @@ import { useExtensionIsInTab } from '@/ui/features/browser/tabs';
 import { useCurrentAccount, useReloadAccounts } from '@/ui/state/accounts/hooks';
 import { useAppDispatch } from '@/ui/state/hooks';
 import { useCurrentKeyring } from '@/ui/state/keyrings/hooks';
-import { satoshisToAmount, useWallet } from '@/ui/utils';
+import { useWallet } from '@/ui/utils';
 
 import { useNavigate } from '../MainRoute';
 
@@ -40,18 +40,19 @@ export default function AddressTypeScreen() {
 
         const _res = await wallet.getAllAddresses(currentKeyring, account.index || 0);
         setAddresses(_res);
-        const balances = await wallet.getMultiAddressAssets(_res.join(','));
-        for (let i = 0; i < _res.length; i++) {
-            const address = _res[i];
-            const balance = balances[i];
-            const satoshis = balance.totalSatoshis;
-            self.addressAssets[address] = {
-                total_btc: satoshisToAmount(balance.totalSatoshis),
-                satoshis,
-                total_inscription: balance.inscriptionCount
-            };
-        }
-        setAddressAssets(self.addressAssets);
+        // TODO: Fix this error (Error: address invalid)
+        // const balances = await wallet.getMultiAddressAssets(_res.join(','));
+        // for (let i = 0; i < _res.length; i++) {
+        //     const address = _res[i];
+        //     const balance = balances[i];
+        //     const satoshis = balance.totalSatoshis;
+        //     self.addressAssets[address] = {
+        //         total_btc: satoshisToAmount(balance.totalSatoshis),
+        //         satoshis,
+        //         total_inscription: balance.inscriptionCount
+        //     };
+        // }
+        // setAddressAssets(self.addressAssets);
 
         tools.showLoading(false);
     };

--- a/src/ui/pages/Settings/AdvancedScreen.tsx
+++ b/src/ui/pages/Settings/AdvancedScreen.tsx
@@ -26,6 +26,7 @@ export default function AdvancedScreen() {
     const [unconfirmedPopoverVisible, setUnconfirmedPopoverVisible] = useState(false);
 
     const [lockTimePopoverVisible, setLockTimePopoverVisible] = useState(false);
+    const [isOPNETonly, setIsOPNETonly] = useState(localStorage.getItem('selectionUser') === 'opnet-only');
     const autoLockTimeId = useAutoLockTimeId();
     const lockTimeConfig = AUTO_LOCKTIMES[autoLockTimeId] || AUTO_LOCKTIMES[DEFAULT_LOCKTIME_ID];
 
@@ -150,6 +151,42 @@ export default function AdvancedScreen() {
                         </Column>
                     </Card>
                 </Column>
+
+                <Column>
+                    <Card style={{ borderRadius: 10 }}>
+                        <Column>
+                            <Text text={'Setup Preferences'} preset="bold" size="sm" />
+                            <Row>
+                                <Text
+                                    preset="sub"
+                                    size="sm"
+                                    text={
+                                        'If you enable this setting, you will only be able to use OP_NET. This means you will not be able to use other standards such as Ordinals, Atomicals, or Runes.'
+                                    }
+                                />
+                            </Row>
+
+                            <Row style={{ borderTopWidth: 1, borderColor: colors.border }} my="md" />
+
+                            <Row justifyBetween>
+                                <Text text={'OP_NET only'} size="xs" />
+
+                                <Switch
+                                    onChange={() => {
+                                        if (isOPNETonly) {
+                                            localStorage.setItem('selectionUser', 'opnet-with-standards');
+                                            setIsOPNETonly(false);
+                                        } else {
+                                            localStorage.setItem('selectionUser', 'opnet-only');
+                                            setIsOPNETonly(true);
+                                        }
+                                    }}
+                                    checked={isOPNETonly}></Switch>
+                            </Row>
+                        </Column>
+                    </Card>
+                </Column>
+
                 <Column>
                     <Card style={{ borderRadius: 10 }}>
                         <Row

--- a/src/ui/state/accounts/hooks.ts
+++ b/src/ui/state/accounts/hooks.ts
@@ -174,11 +174,15 @@ export function useFetchHistoryCallback() {
     const wallet = useWallet();
     const address = useAccountAddress();
     return useCallback(async () => {
-        const _accountHistory = await wallet.getAddressHistory(address);
+        const _accountHistory = await wallet.getAddressHistory({
+            address: address,
+            start: 1,
+            limit: 10
+        });
         dispatch(
             accountActions.setHistory({
                 address: address,
-                list: _accountHistory
+                list: _accountHistory.detail
             })
         );
     }, [dispatch, wallet, address]);


### PR DESCRIPTION
### Changes:
- **Network Configuration:**
  - Changed the default network from:
    ```typescript
    networkType: NetworkType.MAINNET,
    chainType: ChainType.BITCOIN_MAINNET,
    ```
    to:
    ```typescript
    networkType: NetworkType.REGTEST, // TODO: To change to mainnet when mainnet is ready
    chainType: ChainType.BITCOIN_REGTEST, // TODO: To change to mainnet when mainnet is ready
    ```
  - The wallet will now start on `regtest` by default instead of `mainnet`.

- **OP_NET-Only Mode:**
  - Added a new `opNetOnly` flag which is toggleable in the **Advanced Settings**.
  - Allows users to switch between OP_NET-only mode or include support for additional standards (e.g., Ordinals, Atomicals, Runes).

- **Welcome Screen Update:**
  - Updated the welcome message to:
    > "A browser-based extension that allows you to manage your tokens and interact with applications built on the OP_NET metaprotocol."

- **Address Assets Fetching Fix:**
  - Commented out the `getMultiAddressAssets` part, which was causing errors during address type switching (Taproot, etc.):
    ```typescript
    const _res = await wallet.getAllAddresses(currentKeyring, account.index || 0);
    setAddresses(_res);
    // TODO: Fix this error (Error: address invalid)
    // const balances = await wallet.getMultiAddressAssets(_res.join(','));
    // for (let i = 0; i < _res.length; i++) {
    //     const address = _res[i];
    //     const balance = balances[i];
    //     const satoshis = balance.totalSatoshis;
    //     self.addressAssets[address] = {
    //         total_btc: satoshisToAmount(balance.totalSatoshis),
    //         satoshis,
    //         total_inscription: balance.inscriptionCount
    //     };
    // }
    // setAddressAssets(self.addressAssets);
    ```
  - This temporarily resolves the screen glitch during address type changes.

- **Address History Refactor:**
  - Modified `getAddressHistory` and `setHistory` to use correct parameters:
    ```typescript
    return useCallback(async () => {
        const _accountHistory = await wallet.getAddressHistory({
            address: address,
            start: 1,
            limit: 10
        });
        dispatch(
            accountActions.setHistory({
                address: address,
                list: _accountHistory.detail
            })
        );
    }, [dispatch, wallet, address]);
    ```
  - `getAddressHistory` now expects an object instead of a string, and `setHistory` is updated to match the new structure.
