### PR TITLE
Major fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "opwallet",
-    "version": "1.0.61",
+    "version": "1.0.62",
     "private": true,
     "type": "module",
     "homepage": "https://github.com/unisat-wallet/extension#readme",

--- a/src/background/controller/provider/controller.ts
+++ b/src/background/controller/provider/controller.ts
@@ -303,7 +303,9 @@ export class ProviderController {
             interactionParams.bytecode = objToBuffer(interactionParams.bytecode);
 
             // @ts-expect-error
-            interactionParams.calldata = objToBuffer(interactionParams.calldata);
+            interactionParams.calldata = interactionParams.calldata
+                ? objToBuffer(interactionParams.calldata)
+                : Buffer.from([]);
         }
     ])
     deployContract = async (request: {

--- a/src/ui/pages/Approval/components/SignInteraction.tsx
+++ b/src/ui/pages/Approval/components/SignInteraction.tsx
@@ -1,11 +1,12 @@
 import { SignInteractionApprovalParams } from '@/shared/types/Approval';
 import { selectorToString } from '@/shared/web3/decoder/CalldataDecoder';
-import { Button, Card, Column, Content, Footer, Header, Layout, Row, Text } from '@/ui/components';
+import { Button, Card, Column, Content, Footer, Header, Image, Layout, Row, Text } from '@/ui/components';
+import { svgRegistry } from '@/ui/components/Icon';
 import WebsiteBar from '@/ui/components/WebsiteBar';
 import InteractionHeader from '@/ui/pages/Approval/components/Headers/InteractionHeader';
+import { decodeCallData } from '@/ui/pages/OpNet/decoded/decodeCallData';
 import { DecodedCalldata } from '@/ui/pages/OpNet/decoded/DecodedCalldata';
 import { useApproval } from '@/ui/utils/hooks';
-import { decodeCallData } from '@/ui/pages/OpNet/decoded/decodeCallData';
 import { Decoded } from '../../OpNet/decoded/DecodedTypes';
 
 export interface Props {
@@ -32,6 +33,8 @@ export default function SignText(props: Props) {
     const interactionType = selectorToString(data.interactionParameters.calldata as unknown as string);
     const decoded: Decoded | null = decodeCallData(data.interactionParameters.calldata as unknown as string);
     const chain = data.network;
+
+    const optionalOutputs = data.interactionParameters.optionalOutputs;
 
     return (
         <Layout>
@@ -80,6 +83,54 @@ export default function SignText(props: Props) {
                             {`0x${data.interactionParameters.calldata}`}
                         </div>
                     </Card>
+
+                    {optionalOutputs && optionalOutputs.length > 0 && (
+                        <Column mt="lg">
+                            <Text text="Outputs (Where some funds go):" textCenter preset="sub-bold" />
+
+                            <Card style={{ justifyContent: 'start' }}>
+                                <Column style={{ gap: 20, width: '100%' }}>
+                                    {optionalOutputs.map((output, index) => {
+                                        const valueBTC = (output.value / 1e8).toFixed(8).replace(/\.?0+$/, '');
+
+                                        const address =
+                                            'address' in output
+                                                ? `${output.address.slice(0, 6)}...${output.address.slice(-6)}`
+                                                : output.script.toString('hex').slice(0, 10) + '...';
+
+                                        return (
+                                            <Row
+                                                key={index}
+                                                justifyBetween
+                                                style={{
+                                                    alignItems: 'center'
+                                                }}>
+                                                <Text
+                                                    text={address}
+                                                    style={{ fontFamily: 'monospace', fontSize: 14 }}
+                                                />
+
+                                                <div
+                                                    style={{
+                                                        display: 'flex',
+                                                        alignItems: 'center',
+                                                        gap: 3
+                                                    }}>
+                                                    <Text
+                                                        text={valueBTC}
+                                                        style={{ fontFamily: 'monospace', fontSize: 14 }}
+                                                    />
+
+                                                    <Image src={svgRegistry.btc} size={28} />
+                                                </div>
+                                            </Row>
+                                        );
+                                    })}
+                                </Column>
+                            </Card>
+                        </Column>
+                    )}
+
                     <Text
                         text="Only sign this transaction if you fully understand the content and trust the requesting site."
                         preset="sub"

--- a/src/ui/pages/Approval/components/SignInteraction.tsx
+++ b/src/ui/pages/Approval/components/SignInteraction.tsx
@@ -13,7 +13,7 @@ export interface Props {
     params: SignInteractionApprovalParams;
 }
 
-export default function SignText(props: Props) {
+export default function SignInteraction(props: Props) {
     const {
         params: { data, session }
     } = props;
@@ -34,6 +34,9 @@ export default function SignText(props: Props) {
     const decoded: Decoded | null = decodeCallData(data.interactionParameters.calldata as unknown as string);
     const chain = data.network;
 
+    const inputs = data.interactionParameters.utxos;
+
+    const gasSatFee = data.interactionParameters.gasSatFee;
     const optionalOutputs = data.interactionParameters.optionalOutputs;
 
     return (
@@ -84,52 +87,95 @@ export default function SignText(props: Props) {
                         </div>
                     </Card>
 
-                    {optionalOutputs && optionalOutputs.length > 0 && (
+                    {inputs && inputs.length > 0 && (
                         <Column mt="lg">
-                            <Text text="Outputs (Where some funds go):" textCenter preset="sub-bold" />
+                            <Text text="Inputs (UTXOs used):" textCenter preset="sub-bold" />
 
                             <Card style={{ justifyContent: 'start' }}>
                                 <Column style={{ gap: 20, width: '100%' }}>
-                                    {optionalOutputs.map((output, index) => {
-                                        const valueBTC = (output.value / 1e8).toFixed(8).replace(/\.?0+$/, '');
-
-                                        const address =
-                                            'address' in output
-                                                ? `${output.address.slice(0, 6)}...${output.address.slice(-6)}`
-                                                : output.script.toString('hex').slice(0, 10) + '...';
-
-                                        return (
-                                            <Row
-                                                key={index}
-                                                justifyBetween
-                                                style={{
-                                                    alignItems: 'center'
-                                                }}>
+                                    {inputs.map((input, index) => (
+                                        <Row key={index} justifyBetween style={{ alignItems: 'center' }}>
+                                            <Text
+                                                text={`${input.transactionId.slice(0, 6)}...${input.transactionId.slice(-6)}`}
+                                                style={{ fontFamily: 'monospace', fontSize: 14 }}
+                                            />
+                                            <div style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
                                                 <Text
-                                                    text={address}
+                                                    text={(Number(input.value) / 1e8).toFixed(8).replace(/\.?0+$/, '')}
                                                     style={{ fontFamily: 'monospace', fontSize: 14 }}
                                                 />
-
-                                                <div
-                                                    style={{
-                                                        display: 'flex',
-                                                        alignItems: 'center',
-                                                        gap: 3
-                                                    }}>
-                                                    <Text
-                                                        text={valueBTC}
-                                                        style={{ fontFamily: 'monospace', fontSize: 14 }}
-                                                    />
-
-                                                    <Image src={svgRegistry.btc} size={28} />
-                                                </div>
-                                            </Row>
-                                        );
-                                    })}
+                                                <Image src={svgRegistry.btc} size={28} />
+                                            </div>
+                                        </Row>
+                                    ))}
                                 </Column>
                             </Card>
                         </Column>
                     )}
+
+                    <Column mt="lg">
+                        <Text text="Outputs (Where funds go):" textCenter preset="sub-bold" />
+
+                        <Card style={{ justifyContent: 'start' }}>
+                            <Column style={{ gap: 20, width: '100%' }}>
+                                <Row
+                                    justifyBetween
+                                    style={{
+                                        alignItems: 'center'
+                                    }}>
+                                    <Text text="Gas fee" style={{ fontFamily: 'monospace', fontSize: 14 }} />
+
+                                    <div
+                                        style={{
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            gap: 3
+                                        }}>
+                                        <Text
+                                            text={(Number(gasSatFee) / 1e8).toFixed(8).replace(/\.?0+$/, '')}
+                                            style={{ fontFamily: 'monospace', fontSize: 14 }}
+                                        />
+
+                                        <Image src={svgRegistry.btc} size={28} />
+                                    </div>
+                                </Row>
+
+                                {optionalOutputs?.map((output, index) => {
+                                    const valueBTC = (output.value / 1e8).toFixed(8).replace(/\.?0+$/, '');
+
+                                    const address =
+                                        'address' in output
+                                            ? `${output.address.slice(0, 6)}...${output.address.slice(-6)}`
+                                            : output.script.toString('hex').slice(0, 10) + '...';
+
+                                    return (
+                                        <Row
+                                            key={index}
+                                            justifyBetween
+                                            style={{
+                                                alignItems: 'center'
+                                            }}>
+                                            <Text text={address} style={{ fontFamily: 'monospace', fontSize: 14 }} />
+
+                                            <div
+                                                style={{
+                                                    display: 'flex',
+                                                    alignItems: 'center',
+                                                    gap: 3
+                                                }}>
+                                                <Text
+                                                    text={valueBTC}
+                                                    style={{ fontFamily: 'monospace', fontSize: 14 }}
+                                                />
+
+                                                <Image src={svgRegistry.btc} size={28} />
+                                            </div>
+                                        </Row>
+                                    );
+                                })}
+                            </Column>
+                        </Card>
+                    </Column>
 
                     <Text
                         text="Only sign this transaction if you fully understand the content and trust the requesting site."
@@ -143,7 +189,18 @@ export default function SignText(props: Props) {
             <Footer>
                 <Row full>
                     <Button text="Reject" full preset="default" onClick={handleCancel} />
-                    <Button text="Sign" full preset="primary" onClick={handleConfirm} />
+                    <Button
+                        text={`Sign (${(
+                            (Number(gasSatFee) +
+                                (optionalOutputs ?? []).reduce((sum, output) => sum + Number(output.value), 0)) /
+                            1e8
+                        )
+                            .toFixed(8)
+                            .replace(/\.?0+$/, '')} BTC)`}
+                        full
+                        preset="primary"
+                        onClick={handleConfirm}
+                    />
                 </Row>
             </Footer>
         </Layout>

--- a/src/ui/pages/OpNet/decoded/op20/ApproveDecodedInfo.tsx
+++ b/src/ui/pages/OpNet/decoded/op20/ApproveDecodedInfo.tsx
@@ -2,9 +2,11 @@ import BigNumber from 'bignumber.js';
 
 import { ContractInformation } from '@/shared/web3/interfaces/ContractInformation';
 import { Card, Column, Image, Row, Text } from '@/ui/components';
-import { fontSizes } from '@/ui/theme/font';
-import { sliceAddress } from '@/ui/pages/OpNet/decoded/helpper';
 import { DecodedApprove } from '@/ui/pages/OpNet/decoded/DecodedTypes';
+import { sliceAddress } from '@/ui/pages/OpNet/decoded/helpper';
+import { fontSizes } from '@/ui/theme/font';
+
+export const MAX_UINT256 = new BigNumber('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
 
 interface DecodedApproveProps {
     readonly decoded: DecodedApprove;
@@ -22,6 +24,8 @@ export function ApproveDecodedInfo(props: DecodedApproveProps) {
 
     const slicedAddress = sliceAddress(decoded.spender);
 
+    const isUnlimitedApproval = new BigNumber(decoded.amount.toString()).isGreaterThanOrEqualTo(MAX_UINT256);
+
     return (
         <Card>
             <Column>
@@ -29,9 +33,18 @@ export function ApproveDecodedInfo(props: DecodedApproveProps) {
                 <Row>
                     <Image src={contractInfo.logo} size={fontSizes.logo} />
                     <Text
-                        text={`${balanceFormatted} ${(contractInfo.symbol || '').toUpperCase()}`}
+                        text={
+                            isUnlimitedApproval
+                                ? `Unlimited ${(contractInfo.symbol || '').toUpperCase()}`
+                                : `${balanceFormatted} ${(contractInfo.symbol || '').toUpperCase()}`
+                        }
                         preset="large"
                         textCenter
+                        style={{
+                            wordBreak: 'break-word',
+                            overflowWrap: 'break-word',
+                            whiteSpace: 'normal'
+                        }}
                     />
                 </Row>
                 <Text text={`spender: ✓ ${slicedAddress}`} preset="sub" textCenter />

--- a/src/ui/pages/OpNet/decoded/op20/OP20.tsx
+++ b/src/ui/pages/OpNet/decoded/op20/OP20.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ContractInformation } from '@/shared/web3/interfaces/ContractInformation';
 import { Card, Column, Image, Row, Text } from '@/ui/components';
 import { fontSizes } from '@/ui/theme/font';
@@ -15,8 +13,10 @@ import {
     DecodedTransfer,
     DecodedTransferFrom
 } from '@/ui/pages/OpNet/decoded/DecodedTypes';
-import { BitcoinUtils } from 'opnet';
 import { sliceAddress } from '@/ui/pages/OpNet/decoded/helpper';
+import BigNumber from 'bignumber.js';
+import { BitcoinUtils } from 'opnet';
+import { MAX_UINT256 } from './ApproveDecodedInfo';
 
 interface CommonProps {
     readonly contractInfo: Partial<ContractInformation>;
@@ -46,6 +46,11 @@ export function TransferDecodedInfo(props: TransferDecodedProps) {
                         text={`${balanceFormatted} ${(contractInfo.symbol || '').toUpperCase()}`}
                         preset="large"
                         textCenter
+                        style={{
+                            wordBreak: 'break-word',
+                            overflowWrap: 'break-word',
+                            whiteSpace: 'normal'
+                        }}
                     />
                 </Row>
                 <Text text={`recipient: ✓ ${slicedRecipient}`} preset="sub" textCenter />
@@ -78,6 +83,11 @@ export function TransferFromDecodedInfo(props: TransferFromDecodedProps) {
                         text={`${balanceFormatted} ${(contractInfo.symbol || '').toUpperCase()}`}
                         preset="large"
                         textCenter
+                        style={{
+                            wordBreak: 'break-word',
+                            overflowWrap: 'break-word',
+                            whiteSpace: 'normal'
+                        }}
                     />
                 </Row>
                 <Text text={`sender: ✗ ${slicedSender}`} preset="sub" textCenter />
@@ -100,6 +110,8 @@ export function ApproveDecodedInfo(props: ApproveDecodedProps) {
     const balanceFormatted = BitcoinUtils.formatUnits(decoded.amount, contractInfo.decimals || 8);
     const slicedSpender = sliceAddress(decoded.spender);
 
+    const isUnlimitedApproval = new BigNumber(decoded.amount.toString()).isGreaterThanOrEqualTo(MAX_UINT256);
+
     return (
         <Card>
             <Column>
@@ -107,9 +119,18 @@ export function ApproveDecodedInfo(props: ApproveDecodedProps) {
                 <Row>
                     <Image src={contractInfo.logo} size={fontSizes.logo} />
                     <Text
-                        text={`${balanceFormatted} ${(contractInfo.symbol || '').toUpperCase()}`}
+                        text={
+                            isUnlimitedApproval
+                                ? `Unlimited ${(contractInfo.symbol || '').toUpperCase()}`
+                                : `${balanceFormatted} ${(contractInfo.symbol || '').toUpperCase()}`
+                        }
                         preset="large"
                         textCenter
+                        style={{
+                            wordBreak: 'break-word',
+                            overflowWrap: 'break-word',
+                            whiteSpace: 'normal'
+                        }}
                     />
                 </Row>
                 <Text text={`spender: ✓ ${slicedSpender}`} preset="sub" textCenter />
@@ -135,6 +156,8 @@ export function ApproveFromDecodedInfo(props: ApproveFromDecodedProps) {
     // For simplicity, we just show its length
     const signatureLength = decoded.signature?.length || 0;
 
+    const isUnlimitedApproval = new BigNumber(decoded.amount.toString()).isGreaterThanOrEqualTo(MAX_UINT256);
+
     return (
         <Card>
             <Column>
@@ -142,9 +165,18 @@ export function ApproveFromDecodedInfo(props: ApproveFromDecodedProps) {
                 <Row>
                     <Image src={contractInfo.logo} size={fontSizes.logo} />
                     <Text
-                        text={`${balanceFormatted} ${(contractInfo.symbol || '').toUpperCase()}`}
+                        text={
+                            isUnlimitedApproval
+                                ? `Unlimited ${(contractInfo.symbol || '').toUpperCase()}`
+                                : `${balanceFormatted} ${(contractInfo.symbol || '').toUpperCase()}`
+                        }
                         preset="large"
                         textCenter
+                        style={{
+                            wordBreak: 'break-word',
+                            overflowWrap: 'break-word',
+                            whiteSpace: 'normal'
+                        }}
                     />
                 </Row>
                 <Text text={`spender: ✓ ${slicedSpender}`} preset="sub" textCenter />
@@ -176,6 +208,11 @@ export function BurnDecodedInfo(props: BurnDecodedProps) {
                         text={`${balanceFormatted} ${(contractInfo.symbol || '').toUpperCase()} burned`}
                         preset="large"
                         textCenter
+                        style={{
+                            wordBreak: 'break-word',
+                            overflowWrap: 'break-word',
+                            whiteSpace: 'normal'
+                        }}
                     />
                 </Row>
             </Column>
@@ -206,6 +243,11 @@ export function MintDecodedInfo(props: MintDecodedProps) {
                         text={`${balanceFormatted} ${(contractInfo.symbol || '').toUpperCase()} minted`}
                         preset="large"
                         textCenter
+                        style={{
+                            wordBreak: 'break-word',
+                            overflowWrap: 'break-word',
+                            whiteSpace: 'normal'
+                        }}
                     />
                 </Row>
                 <Text text={`to: ✓ ${slicedAddr}`} preset="sub" textCenter />
@@ -258,6 +300,11 @@ export function AirdropWithAmountDecodedInfo(props: AirdropWithAmountProps) {
                     text={`Airdrop with Amount: ${balanceFormatted} ${(contractInfo.symbol || '').toUpperCase()}`}
                     preset="large"
                     textCenter
+                    style={{
+                        wordBreak: 'break-word',
+                        overflowWrap: 'break-word',
+                        whiteSpace: 'normal'
+                    }}
                 />
                 <Text text={`Addresses:`} preset="sub-bold" textCenter />
                 {decoded.addresses?.map((addr, i) => (

--- a/src/ui/pages/Wallet/TxFailScreen.tsx
+++ b/src/ui/pages/Wallet/TxFailScreen.tsx
@@ -19,20 +19,38 @@ export default function TxFailScreen() {
 
                     <Text preset="title" text="Payment Failed" textCenter />
                     {error.split('\n').map((line, index) => {
-                        return (
-                            <Text
-                                key={index}
-                                preset="regular-bold"
-                                style={{
-                                    color: colors.red,
-                                    backgroundColor: 'rgba(225, 45, 53, 0.1)',
-                                    padding: 5,
-                                    borderRadius: 7
-                                }}
-                                text={line}
-                                textCenter
-                            />
-                        );
+                        switch (line) {
+                            case 'Expected value to be of type Address (recipient)':
+                                return (
+                                    <Text
+                                        key={index}
+                                        preset="regular-bold"
+                                        style={{
+                                            color: colors.red,
+                                            backgroundColor: 'rgba(225, 45, 53, 0.1)',
+                                            padding: 5,
+                                            borderRadius: 7
+                                        }}
+                                        text="The recipient's public key was not found. Please provide their public key directly to proceed with the transaction."
+                                        textCenter
+                                    />
+                                );
+                            default:
+                                return (
+                                    <Text
+                                        key={index}
+                                        preset="regular-bold"
+                                        style={{
+                                            color: colors.red,
+                                            backgroundColor: 'rgba(225, 45, 53, 0.1)',
+                                            padding: 5,
+                                            borderRadius: 7
+                                        }}
+                                        text={line}
+                                        textCenter
+                                    />
+                                );
+                        }
                     })}
                 </Column>
             </Content>


### PR DESCRIPTION
- Remove that we need to add `Buffer.from([])` in calldata when deploying a contract outside of the wallet.

- Fix overflowing numbers when approving, etc.

- Improve the error message when sending an OP_20 token to any address (P2TR, etc.) and the public key of the recipient is not found.

- Add the preview of `optionalOutputs` during an interaction.

- Bump to `1.0.62`.