### PR TITLE
Fix crash when using op404 tokens

### DIFF
--- a/src/shared/constant/index.ts
+++ b/src/shared/constant/index.ts
@@ -487,6 +487,8 @@ export const COIN_SYMBOL = 'BTC';
 
 export const COIN_DUST = 1000;
 
+export const DEFAULT_TOKEN_DECIMALS = 18;
+
 export const GITHUB_URL = 'https://github.com/btc-vision/opwallet';
 export const TWITTER_URL = 'https://x.com/opnetbtc';
 export const TELEGRAM_URL = 'https://t.me/opnetbtc ';

--- a/src/shared/web3/Web3API.ts
+++ b/src/shared/web3/Web3API.ts
@@ -11,7 +11,7 @@ import {
     UTXOs
 } from 'opnet';
 
-import { ChainId as WalletChainId, ChainType } from '@/shared/constant';
+import { ChainId as WalletChainId, ChainType, DEFAULT_TOKEN_DECIMALS } from '@/shared/constant';
 import { NetworkType } from '@/shared/types';
 import { customNetworksManager } from '@/shared/utils/CustomNetworksManager';
 import { contractLogoManager } from '@/shared/web3/contracts-logo/ContractLogoManager';
@@ -109,6 +109,13 @@ export function bigIntToDecimal(amount: bigint, decimal: number): string {
     return number.decimalPlaces(decimal).toPrecision();
 }
 
+type ConstantTokenInfo = {
+    name: string;
+    symbol: string;
+    decimals: number;
+    icon: string;
+};
+
 class Web3API {
     public readonly INVALID_PUBKEY_ERROR: string =
         'Please use the recipient token deposit address (aka "public key").\nOP_NET was unable to automatically find the public key associated with the address you are trying to send to because this address never spent an UTXO before.';
@@ -119,6 +126,8 @@ class Web3API {
     public transactionFactory: TransactionFactory = new TransactionFactory();
 
     private currentChain?: ChainType;
+
+    private infoCache: Map<string, ConstantTokenInfo> = new Map();
 
     //constructor() {
     // Initialize with default, will be set properly when setNetwork is called
@@ -243,6 +252,31 @@ class Web3API {
         return !!AddressVerificator.detectAddressType(address, this.network);
     }
 
+    /**
+     * Get contract metadata (name, symbol, decimals, etc.)
+     * @param contract - Contract
+     * @returns Constant contract information from cache or newly fetched
+     */
+    private async getConstantContractInfo(contract: IOP20Contract): Promise<ConstantTokenInfo> {
+        let info: ConstantTokenInfo | undefined = this.infoCache.get(contract.p2op);
+        if (!info) {
+            const results = await Promise.all([
+                contract.name(),
+                contract.symbol(),
+                contract.decimals(),
+                contract.icon()
+            ]);
+            const name = results[0]?.properties?.name ?? 'Unknown';
+            const symbol = results[1]?.properties?.symbol ?? 'UNKNOWN';
+            const decimals = results[2]?.properties?.decimals ?? 0;
+            const icon = results[3]?.properties?.icon || '';
+
+            info = { name, symbol, decimals, icon };
+            this.infoCache.set(contract.p2op, info);
+        }
+        return info;
+    }
+
     public async queryDecimal(address: string): Promise<number> {
         const genericContract: IOP20Contract = getContract<IOP20Contract>(
             address,
@@ -273,25 +307,18 @@ class Web3API {
                 this.network
             );
 
-            const results = await Promise.all([
-                genericContract.metadata(),
+            const [info, supply, icon]= await Promise.all([
+                this.getConstantContractInfo(genericContract),
+                genericContract.totalSupply(),
                 contractLogoManager.getContractLogo(addressP2OP)
             ]);
 
-            const metadata = results[0].properties;
-
-            const name = metadata.name ?? this.getContractName(addressP2OP);
-            const symbol = metadata.symbol ?? 'UNKNOWN';
-            const decimals = metadata.decimals ?? 0;
-            const totalSupply = metadata.totalSupply ?? 0n;
-
-            const logo = metadata.icon || results[1];
             return {
-                name,
-                symbol,
-                decimals,
-                logo,
-                totalSupply
+                name: info.name ?? this.getContractName(addressP2OP),
+                symbol: info.symbol ?? 'UNKNOWN',
+                decimals: info.decimals ?? 0,
+                logo: info.icon || icon,
+                totalSupply: supply.properties.totalSupply ?? 0n
             };
         } catch (e) {
             console.warn(`Couldn't query name/symbol/decimals/logo for contract ${address}:`, e);
@@ -299,6 +326,55 @@ class Web3API {
                 return false;
             }
             return;
+        }
+    }
+
+    /*
+     * Try to get contract decimals
+     * If contract have a OP20 parts, decimals default to 18 if not specified
+     * else it defaults to 0 as the contract should be pure OP721
+     */
+    public async getDecimals(collectionAddress: string): Promise<number> {
+        try {
+            let addressP2OP: string = collectionAddress;
+            if (collectionAddress.startsWith('0x')) {
+                addressP2OP = Address.fromString(collectionAddress).p2op(this.network);
+            }
+
+            const tokenContract: IOP20Contract = getContract<IOP20Contract>(
+                addressP2OP,
+                OP_20_ABI,
+                this.provider,
+                this.network
+            );
+            const decimals = await tokenContract.decimals();
+            return decimals?.properties?.decimals || DEFAULT_TOKEN_DECIMALS;
+        } catch (e) {
+            return 0;
+        }
+    }
+
+    public async getOwnedNFTsCount(collectionAddress: string, ownerAddress: Address): Promise<number | undefined> {
+        try {
+            let addressP2OP: string = collectionAddress;
+            if (collectionAddress.startsWith('0x')) {
+                addressP2OP = Address.fromString(collectionAddress).p2op(this.network);
+            }
+
+            const nftContract: IExtendedOP721 = getContract<IExtendedOP721>(
+                addressP2OP,
+                EXTENDED_OP721_ABI,
+                this.provider,
+                this.network
+            );
+
+            const decimals = await this.getDecimals(addressP2OP);
+            const balance = await nftContract.balanceOf(ownerAddress);
+            const divider = Math.pow(10, decimals);
+            return Number(balance?.properties?.balance || 0) / divider;
+        } catch (e) {
+            console.log('getOwnedNFTsCount error getting balance', e);
+            return undefined;
         }
     }
 
@@ -319,10 +395,13 @@ class Web3API {
                 this.network
             );
 
-            const balance = await nftContract.balanceOf(ownerAddress);
+            const balanceOf = await nftContract.balanceOf(ownerAddress);
+            const decimals = await this.getDecimals(addressP2OP);
+            const divider = Math.pow(10, decimals);
+            const balance = Number(balanceOf?.properties?.balance || 0) / divider;
 
             const ownedNFTs: Promise<TokenOfOwnerByIndex>[] = [];
-            for (let i = 0n; i < balance.properties.balance; i++) {
+            for (let i = 0n; i < balance; i++) {
                 ownedNFTs.push(nftContract.tokenOfOwnerByIndex(ownerAddress, i));
             }
 

--- a/src/ui/pages/Main/NFTTabScreen/index.tsx
+++ b/src/ui/pages/Main/NFTTabScreen/index.tsx
@@ -11,6 +11,8 @@ import { useChain, useChainType } from '@/ui/state/settings/hooks';
 import { LoadingOutlined, PlusOutlined } from '@ant-design/icons';
 import { Address } from '@btc-vision/transaction';
 import React, { useEffect, useState } from 'react';
+import { Account } from '@/shared/types';
+import { ChainType } from '@/shared/constant';
 
 const colors = {
     main: '#f37413',
@@ -45,6 +47,7 @@ interface CacheItem<T> {
 class NFTCache {
     private metadata = new Map<string, CacheItem<NFTMetadata>>();
     private ownedNfts = new Map<string, CacheItem<OwnedNFT[]>>();
+    private ownedNftsCount = new Map<string, CacheItem<number>>();
 
     setMetadata(key: string, data: NFTMetadata, ttl: number = 7200000) {
         this.metadata.set(key, {
@@ -55,6 +58,14 @@ class NFTCache {
 
     setOwnedNfts(key: string, data: OwnedNFT[], ttl: number = 30000) {
         this.ownedNfts.set(key, {
+            data,
+            expiry: Date.now() + ttl
+        });
+    }
+
+    setOwnedNftsCount(account: Account, chainType: ChainType, address: string, data: number, ttl: number = 30000) {
+        const key = `opnet_nft_collections_count_${chainType}_${account.pubkey}_${address}`;
+        this.ownedNftsCount.set(key, {
             data,
             expiry: Date.now() + ttl
         });
@@ -79,6 +90,17 @@ class NFTCache {
         }
         return item.data;
     }
+
+    getOwnedNftsCount(account: Account, chainType: ChainType, address: string): number | undefined {
+        const storageKey = `opnet_nft_collections_count_${chainType}_${account.pubkey}_${address}`;
+        const item = this.ownedNftsCount.get(storageKey);
+        if (!item) return undefined;
+        if (Date.now() > item.expiry) {
+            this.ownedNftsCount.delete(storageKey);
+            return undefined;
+        }
+        return item.data;
+    }
 }
 
 const nftCache = new NFTCache();
@@ -90,7 +112,6 @@ export default function NFTTabScreen() {
     const chain = useChain();
 
     const [collections, setCollections] = useState<NFTCollection[]>([]);
-    const [collectionCounts, setCollectionCounts] = useState<Record<string, number>>({});
     const [selectedCollection, setSelectedCollection] = useState<NFTCollection | null>(null);
     const [ownedNFTs, setOwnedNFTs] = useState<OwnedNFT[]>([]);
     const [loadingNFTs, setLoadingNFTs] = useState(false);
@@ -102,46 +123,6 @@ export default function NFTTabScreen() {
         setCollections(updatedCollections);
         localStorage.setItem(storageKey, JSON.stringify(updatedCollections));
     };
-
-    useEffect(() => {
-        const fetchCollectionCounts = async () => {
-            // Skip if no quantum key (migration not complete)
-            if (!currentAccount.quantumPublicKeyHash) {
-                return;
-            }
-
-            const counts: Record<string, number> = {};
-            const userAddress = Address.fromString(currentAccount.quantumPublicKeyHash, currentAccount.pubkey);
-
-            for (const collection of collections) {
-                const cacheKey = `${collection.address}-${currentAccount.pubkey}`;
-                const cached = nftCache.getOwnedNfts(cacheKey);
-
-                if (cached) {
-                    counts[collection.address] = cached.length;
-                } else {
-                    try {
-                        const nfts = await Web3API.getOwnedNFTsForCollection(collection.address, userAddress);
-                        if (nfts && typeof nfts !== 'boolean') {
-                            counts[collection.address] = nfts.length;
-                            nftCache.setOwnedNfts(cacheKey, nfts);
-                        } else {
-                            counts[collection.address] = 0;
-                        }
-                    } catch (error) {
-                        console.error(`Failed to fetch NFTs for ${collection.address}:`, error);
-                        counts[collection.address] = 0;
-                    }
-                }
-            }
-
-            setCollectionCounts(counts);
-        };
-
-        if (collections.length > 0) {
-            void fetchCollectionCounts();
-        }
-    }, [collections, currentAccount.pubkey]);
 
     useEffect(() => {
         const storedCollections = localStorage.getItem(storageKey);
@@ -327,7 +308,6 @@ export default function NFTTabScreen() {
                                             collection={collection}
                                             onClick={() => handleCollectionClick(collection)}
                                             onDelete={() => handleDeleteCollection(collection.address)}
-                                            ownedCount={collectionCounts[collection.address]}
                                         />
                                     ))}
                                 </div>
@@ -390,13 +370,32 @@ function CollectionCard({
     collection,
     onClick,
     onDelete,
-    ownedCount
 }: {
     collection: NFTCollection;
     onClick: () => void;
     onDelete: () => void;
-    ownedCount?: number;
 }) {
+    const currentAccount = useCurrentAccount();
+    const chainType = useChainType();
+
+    const [ownedCount, setOwnedCount] = useState<number | undefined>(
+        nftCache.getOwnedNftsCount(currentAccount, chainType, collection.address)
+    );
+
+    useEffect(() => {
+        if (!currentAccount.quantumPublicKeyHash) return;
+        if (ownedCount !== undefined) return;
+
+        const userAddress = Address.fromString(currentAccount.quantumPublicKeyHash, currentAccount.pubkey);
+        Web3API.getOwnedNFTsCount(collection.address, userAddress)
+            .then(count => {
+                if (count !== undefined) {
+                    setOwnedCount(count);
+                    nftCache.setOwnedNftsCount(currentAccount, chainType, collection.address, count);
+                }
+            })
+    })
+
     const handleDelete = (e: React.MouseEvent) => {
         e.stopPropagation();
         if (window.confirm(`Remove ${collection.name} from your collections?`)) {

--- a/src/ui/pages/Wallet/ImportOP20Screen.tsx
+++ b/src/ui/pages/Wallet/ImportOP20Screen.tsx
@@ -9,6 +9,7 @@ import { useChain, useChainType } from '@/ui/state/settings/hooks';
 import { CheckCircleOutlined, DollarOutlined, PlusCircleOutlined, SearchOutlined, StarOutlined } from '@ant-design/icons';
 import { Address, AddressTypes, AddressVerificator } from '@btc-vision/transaction';
 import { useEffect, useState } from 'react';
+import { DEFAULT_TOKEN_DECIMALS } from '@/shared/constant';
 
 const colors = {
     main: '#f37413',
@@ -147,7 +148,7 @@ export default function ImportTokenScreen() {
                     address: type === AddressTypes.P2OP ? address : Address.fromString(address).p2op(Web3API.network),
                     name: info.name || 'Unknown Token',
                     symbol: info.symbol || 'UNKNOWN',
-                    decimals: info.decimals || 18,
+                    decimals: info.decimals || DEFAULT_TOKEN_DECIMALS,
                     totalSupply: info.totalSupply?.toString() || '0',
                     icon: info.logo
                 });


### PR DESCRIPTION
## Description
Fix crash wih OP404 satlantis hybrid token.
Also fix invalid amount displayed from satlantis token.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes
- [ ] Dependencies update

## Checklist

### Build & Tests

- [X] `npm install` completes without errors
- [X] `npm run build:chrome` builds successfully
- [ ] Extension loads without errors in browser

### Code Quality

- [ ] Code follows the project's coding standards
- [X] No new TypeScript/ESLint warnings introduced
- [ ] Error handling is appropriate
- [X] Console logs removed (except for error logging)

### Documentation

- [ ] Code comments added for complex logic
- [ ] README updated (if applicable)

### Security

- [ ] No sensitive data (keys, credentials) committed
- [ ] No new security vulnerabilities introduced
- [ ] Private keys are never logged or exposed
- [ ] User inputs are properly validated

### OPWallet Specific

- [ ] Changes work across all supported browsers (Chrome, Firefox, Brave, Edge, Opera)
- [ ] Wallet state management is handled correctly
- [ ] Transaction signing follows security best practices
- [ ] RPC communication is secure
- [ ] Content script isolation is maintained
- [ ] Background/popup communication is secure

## Testing
Tested on Chrome browser

### Browser Testing

- [X] Chrome
- [ ] Firefox
- [ ] Brave
- [ ] Edge
- [ ] Opera

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

---

By submitting this PR, I confirm that my contribution is made under the terms of the project's license.
